### PR TITLE
Specify Tensorflow version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib==2.1.0
-tensorflow
+tensorflow==1.15
 inflect==0.2.5
 librosa==0.6.0
 scipy==1.0.0


### PR DESCRIPTION
Installing this in November 2019, the default version of TF that gets pulled in is 2.0, which no longer includes the contrib module, which leads to errors. Specifying the version as 1.15 fixes that.